### PR TITLE
Fixed state management during postbacks and script errors

### DIFF
--- a/TreeNodeSelector/Properties/AssemblyInfo.cs
+++ b/TreeNodeSelector/Properties/AssemblyInfo.cs
@@ -12,6 +12,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("0374cee8-6a4c-4bc9-ab21-2fe43366e92f")]
 
-[assembly: AssemblyVersion("1.0.6.0")]
-[assembly: AssemblyFileVersion("1.0.6.0")]
+[assembly: AssemblyVersion("1.0.7.0")]
+[assembly: AssemblyFileVersion("1.0.7.0")]
 [assembly: AssemblyDiscoverable()]

--- a/TreeNodeSelector/TreeNodeSelector.nuspec
+++ b/TreeNodeSelector/TreeNodeSelector.nuspec
@@ -12,6 +12,10 @@
 		<license type="expression">MIT</license>
 		<description>$description$</description>
 		<releaseNotes>
+		1.0.7 - Fixed bug that caused item removal or sorting to be lost during postbacks triggered by sibling controls.
+		      - Added caching to improve postback performance.
+			  - Optimized queries of multiple treenodes.
+			  - Resolved script error caused by removal of DeviceContext/OEIsMobile from Kentico 13.
 		1.0.6 - Fixed bug that prevented users from having more than one word in search query
 		1.0.5 - Fixed bug that prevented limiting page selection to exactly two.
 		      - Updated Kentico.Xperience.Libraries 13.0.13 to prevent requiring an assemblyBinding to continuousintegration.exe.config.


### PR DESCRIPTION
- Fixed bug that caused item removal or sorting to be lost during postbacks triggered by sibling controls.
- Added caching to improve postback performance.
- Optimized queries of multiple treenodes.
- Resolved script error caused by removal of DeviceContext/OEIsMobile from Kentico 13.